### PR TITLE
CORE-764 Hazelops nat instance module is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,14 @@
 ```hcl
 module "nat_instance" {
     source    = "hazelops/ec2-nat/aws"
-    version   = "~> 1.0"
-
+    version   = "~> 2.0"
     enabled                 = var.nat_gateway_enabled ? false : true
-
     env                     = var.env
     vpc_id                  = module.vpc.vpc_id
     allowed_cidr_blocks     = [module.vpc.vpc_cidr_block]
     public_subnets          = module.vpc.public_subnets
     private_route_table_id  = module.vpc.private_route_table_ids[0]
-    ec2_key_pair_name       = local.key_name
+    ec2_key_pair_name       = var.ec2_key_pair_name
 }
 ```
 
@@ -24,14 +22,50 @@ module "nat_instance" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
-No Modules.
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_eip_association.nat_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) | resource |
+| [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_architecture"></a> [architecture](#input\_architecture) | NAT instance architecture | `list(string)` | <pre>[<br>  "arm64"<br>]</pre> | no |
+| <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | n/a | `any` | n/a | yes |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Gives ability to enable or disable Creation of NAT EC2 | `bool` | `false` | no |
+| <a name="input_env"></a> [env](#input\_env) | n/a | `any` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | NAT instance type | `string` | `"t4g.nano"` | no |
+| <a name="input_private_route_table_id"></a> [private\_route\_table\_id](#input\_private\_route\_table\_id) | n/a | `any` | n/a | yes |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | n/a | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | n/a |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | n/a |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | n/a |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |

--- a/data.tf
+++ b/data.tf
@@ -2,19 +2,29 @@ data "aws_caller_identity" "current" {}
 
 data "aws_availability_zones" "all" {}
 
+# AMI of the latest Amazon Linux 2
 data "aws_ami" "this" {
   count       = var.enabled ? 1 : 0
   most_recent = true
-
+  owners      = ["amazon"]
+  filter {
+    name   = "architecture"
+    values = var.architecture
+  }
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
   filter {
     name   = "name"
-    values = ["amzn-ami-vpc-nat*"]
+    values = ["al2023-ami-minimal*"]
   }
-
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }
-
-  owners = ["amazon"]
+  filter {
+    name   = "block-device-mapping.volume-type"
+    values = ["gp3"]
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "aws_instance" "this" {
 
 resource "aws_eip" "this" {
   count = var.enabled ? 1 : 0
-  vpc   = true
+  domain = "vpc"
 
   lifecycle {
     create_before_destroy = true
@@ -76,8 +76,8 @@ resource "aws_eip_association" "nat_instance" {
 }
 
 resource "aws_route" "this" {
-  count                  = var.enabled ? 1 : 0
-  route_table_id         = var.private_route_table_id
-  instance_id            = element(aws_instance.this.*.id, count.index)
+  count = var.enabled ? 1 : 0
+  route_table_id = var.private_route_table_id
+  network_interface_id = element(aws_instance.this.*.primary_network_interface_id, count.index)
   destination_cidr_block = "0.0.0.0/0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,18 +5,25 @@ variable "public_subnets" {}
 variable "ec2_key_pair_name" {}
 
 variable "instance_type" {
-  default = "t3.nano"
+  description = "NAT instance type"
+  type = string
+  default = "t4g.nano"
+}
+variable "architecture" {
+  description = "NAT instance architecture"
+  type        = list(string)
+  default     = ["arm64"]
 }
 
 variable "enabled" {
+  description = "Gives ability to enable or disable Creation of NAT EC2"
   type        = bool
   default     = false
-  description = "Gives ability to enable or disable Creation of NAT EC2"
 }
 
 variable "allowed_cidr_blocks" {
-  type        = list(string)
   description = "List of network subnets that are allowed"
+  type        = list(string)
   default = [
     "0.0.0.0/0"
   ]


### PR DESCRIPTION
#### What's new:

 - Module fixed:
   - removed and replaced deprecated parameter (vpc=true & instance_id replaced by network_interface_id)
- Update Amazon instance image template to work
- Added possibility to use ARM64 instance (set by default)

#### Testing done:

Deploy succesful:
<img width="758" alt="Screenshot 2024-11-14 at 15 09 44" src="https://github.com/user-attachments/assets/8eb00d77-1026-4773-892f-a0ba0649cabc">

VPC:
<img width="1204" alt="Screenshot 2024-11-14 at 14 48 31" src="https://github.com/user-attachments/assets/91b2bbc6-220d-43c0-b3db-807e810c1775">

VPC uses NAT instance
<img width="1151" alt="Screenshot 2024-11-14 at 14 47 26" src="https://github.com/user-attachments/assets/1b1f8cc2-aa1e-4b78-a1fb-5a7ff1696653">

NAT instance created:
<img width="1161" alt="Screenshot 2024-11-14 at 14 42 58" src="https://github.com/user-attachments/assets/d2d1b202-2d13-4ffc-b1a9-fe2e022bbeed">


#### Additional info:
I think, after we merge this - I will create next version(3.0) release.
