### PR TITLE
CORE-771 AWS EC2 NAT instance proxy installed using template & CORE-777 AWS-EC2-NAT instance: availability to turn off EIP added

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ No modules.
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of network subnets that are allowed | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | NAT instance architecture | `list(string)` | <pre>[<br>  "arm64"<br>]</pre> | no |
 | <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | n/a | `any` | n/a | yes |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Gives ability to enable or disable Creation of NAT EC2 | `bool` | `false` | no |
+| <a name="input_eip_enabled"></a> [eip\_enabled](#input\_eip\_enabled) | Gives ability to enable or disable creation of Elastic IP | `bool` | `false` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Gives ability to enable or disable creation of NAT EC2 | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `any` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | NAT instance type | `string` | `"t4g.nano"` | no |
 | <a name="input_name"></a> [name](#input\_name) | NAT instance name | `string` | `"nat-instance"` | no |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "nat_instance" {
 }
 ```
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -72,3 +73,4 @@ No modules.
 | <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | n/a |
 | <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | n/a |
 | <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ```hcl
 module "nat_instance" {
     source    = "hazelops/ec2-nat/aws"
-    version   = "~> 2.0"
+    version   = "~> 3.0"
     enabled                 = var.nat_gateway_enabled ? false : true
     env                     = var.env
     vpc_id                  = module.vpc.vpc_id
@@ -28,7 +28,8 @@ module "nat_instance" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.77.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
@@ -46,6 +47,7 @@ No modules.
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [template_file.ec2_user_data](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
@@ -57,6 +59,7 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Gives ability to enable or disable Creation of NAT EC2 | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `any` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | NAT instance type | `string` | `"t4g.nano"` | no |
+| <a name="input_name"></a> [name](#input\_name) | NAT instance name | `string` | `"nat-instance"` | no |
 | <a name="input_private_route_table_id"></a> [private\_route\_table\_id](#input\_private\_route\_table\_id) | n/a | `any` | n/a | yes |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | n/a | `any` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `any` | n/a | yes |

--- a/data.tf
+++ b/data.tf
@@ -2,7 +2,14 @@ data "aws_caller_identity" "current" {}
 
 data "aws_availability_zones" "all" {}
 
-# AMI of the latest Amazon Linux 2
+data "template_file" "ec2_user_data" {
+  template = file("${path.module}/ec2_user_data.yml.tpl")
+  vars = {
+    hostname         = "${var.env}-${var.name}"
+  }
+}
+
+# AMI of the latest Amazon Linux 2023
 data "aws_ami" "this" {
   count       = var.enabled ? 1 : 0
   most_recent = true

--- a/ec2_user_data.yml.tpl
+++ b/ec2_user_data.yml.tpl
@@ -1,0 +1,13 @@
+#cloud-config
+hostname: ${hostname}
+packages:
+  - iptables-services
+write_files:
+  - path: /etc/sysctl.conf
+    content: |
+      net.ipv4.ip_forward = 1
+runcmd:
+  - sysctl -p /etc/sysctl.conf
+  - iptables -t nat -A POSTROUTING -o ens5 -s 0.0.0.0/0 -j MASQUERADE
+  - sysctl enable iptables
+  - sysctl start iptables

--- a/eip.tf
+++ b/eip.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "this" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && var.eip_enabled ? 1 : 0
   domain = "vpc"
 
   lifecycle {
@@ -14,11 +14,10 @@ resource "aws_eip" "this" {
 }
 
 resource "aws_eip_association" "nat_instance" {
-  count         = var.enabled ? 1 : 0
+  count         = var.enabled && var.eip_enabled ? 1 : 0
+  depends_on = [aws_eip.this]
   instance_id   = element(aws_instance.this.*.id, count.index)
   allocation_id = aws_eip.this[count.index].id
-
-  depends_on = [aws_eip.this]
 }
 
 resource "aws_route" "this" {

--- a/eip.tf
+++ b/eip.tf
@@ -7,7 +7,7 @@ resource "aws_eip" "this" {
   }
 
   tags = {
-    "Name" = "${var.env}-nat-instance"
+    "Name" = "${var.env}-${var.name}"
   }
 
   depends_on = [aws_instance.this]

--- a/eip.tf
+++ b/eip.tf
@@ -1,0 +1,29 @@
+resource "aws_eip" "this" {
+  count = var.enabled ? 1 : 0
+  domain = "vpc"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    "Name" = "${var.env}-nat-instance"
+  }
+
+  depends_on = [aws_instance.this]
+}
+
+resource "aws_eip_association" "nat_instance" {
+  count         = var.enabled ? 1 : 0
+  instance_id   = element(aws_instance.this.*.id, count.index)
+  allocation_id = aws_eip.this[count.index].id
+
+  depends_on = [aws_eip.this]
+}
+
+resource "aws_route" "this" {
+  count = var.enabled ? 1 : 0
+  route_table_id = var.private_route_table_id
+  network_interface_id = element(aws_instance.this.*.primary_network_interface_id, count.index)
+  destination_cidr_block = "0.0.0.0/0"
+}

--- a/output.tf
+++ b/output.tf
@@ -7,9 +7,9 @@ output "security_group" {
 }
 
 output "public_ip" {
-  value = element(aws_eip.this.*.public_ip, 0)
+  value = var.eip_enabled ?  element(aws_eip.this.*.public_ip, 0) : aws_instance.this.public_ip
 }
 
 output "private_ip" {
-  value = element(aws_eip.this.*.private_ip, 0)
+  value = var.eip_enabled ? element(aws_eip.this.*.private_ip, 0) : aws_instance.this.private_ip
 }

--- a/security.tf
+++ b/security.tf
@@ -1,0 +1,29 @@
+# Security Groups
+resource "aws_security_group" "this" {
+  count       = var.enabled ? 1 : 0
+  name        = "${var.env}-${var.name}"
+  description = "Security Group for NAT EC2 Instance"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow ingress traffic from the VPC CIDR block"
+    protocol    = -1
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = var.allowed_cidr_blocks
+  }
+
+  egress {
+    description = "Allow all egress traffic"
+    protocol    = -1
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Terraform = "true"
+    Env       = var.env
+    Name      = "${var.env}-nat-instance"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,17 @@ variable "private_route_table_id" {}
 variable "public_subnets" {}
 variable "ec2_key_pair_name" {}
 
+variable "name" {
+  description = "NAT instance name"
+  default = "nat-instance"
+}
+
 variable "instance_type" {
   description = "NAT instance type"
   type = string
   default = "t4g.nano"
 }
+
 variable "architecture" {
   description = "NAT instance architecture"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -23,9 +23,15 @@ variable "architecture" {
 }
 
 variable "enabled" {
-  description = "Gives ability to enable or disable Creation of NAT EC2"
+  description = "Gives ability to enable or disable creation of NAT EC2"
   type        = bool
   default     = false
+}
+
+variable "eip_enabled" {
+  description = "Gives ability to enable or disable creation of Elastic IP"
+  type = bool
+  default = false
 }
 
 variable "allowed_cidr_blocks" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "ec2_key_pair_name" {}
 
 variable "name" {
   description = "NAT instance name"
+  type = string
   default = "nat-instance"
 }
 


### PR DESCRIPTION
#### What's new:

- New Amazon 2023 image used
- Possibility to use ARM64 instances enabled
- Possibility to turn EIP off added (disabled by default)


#### Testing done:

Deploy succesful: 
<img width="1266" alt="Screenshot 2024-11-22 at 14 56 08" src="https://github.com/user-attachments/assets/2fdfdac2-b54b-432e-898f-5edf24b9543c">


Instance:
<img width="1212" alt="Screenshot 2024-11-22 at 14 56 37" src="https://github.com/user-attachments/assets/03d6c5c0-d9f0-4e39-bb28-4b9e6fca5e90">
